### PR TITLE
feat(buildnum): Add helm charts for jx controller buildnumbers.

### DIFF
--- a/prow/templates/_helpers.tpl
+++ b/prow/templates/_helpers.tpl
@@ -47,6 +47,10 @@ Expand the name of the chart.
 {{- default "tot" .Values.tot.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "buildnum.name" -}}
+{{- default "buildnum" .Values.buildnum.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/prow/templates/buildnum-deployment.yaml
+++ b/prow/templates/buildnum-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "buildnum.name" . }}
+  labels:
+    app: {{ template "buildnum.name" . }}
+spec:
+  replicas: 1 # one canonical source of build numbers
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "buildnum.name" . }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.buildnum.terminationGracePeriodSeconds }}
+      containers:
+      - name: {{ template "buildnum.name" . }}
+        image: {{ .Values.buildnum.image.repository }}:{{ .Values.buildnum.image.tag }}
+        imagePullPolicy: {{ .Values.buildnum.imagePullPolicy }}
+{{ if .Values.buildnum.command }}
+        command:
+{{ toYaml .Values.buildnum.command | indent 10 }}
+{{- end }}
+{{ if .Values.buildnum.args }}
+        args:
+{{ toYaml .Values.buildnum.args | indent 10 }}
+{{- end }}
+        resources:
+{{ toYaml .Values.buildnum.resources | indent 10 }}
+        ports:
+          - name: http
+            containerPort: {{ .Values.buildnum.service.internalPort }}
+            protocol: TCP

--- a/prow/templates/buildnum-service.yaml
+++ b/prow/templates/buildnum-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "buildnum.name" . }}
+spec:
+  type: {{ .Values.buildnum.service.type }}
+  selector:
+    app: {{ template "buildnum.name" . }}
+  ports:
+  - port: {{ .Values.buildnum.service.externalPort }}
+    targetPort: {{ .Values.buildnum.service.internalPort }}
+    protocol: TCP
+    name: http

--- a/prow/values.yaml
+++ b/prow/values.yaml
@@ -54,6 +54,30 @@ tot:
   pvc:
     size: 1Gi
 
+buildnum:
+  image:
+    repository: jenkinsxio/jx
+    tag: 1.3.574
+  imagePullPolicy: IfNotPresent
+  terminationGracePeriodSeconds: 180
+  command:
+  - jx
+  args:
+  - "controller"
+  - "buildnumbers"
+  resources:
+    limits:
+     cpu: 400m
+     memory: 256Mi
+    requests:
+     cpu: 200m
+     memory: 128Mi
+  service:
+    type: ClusterIP
+    externalPort: 80
+    internalPort: 8080
+
+
 crier:
   image:
     repository: docker.io/garethjevans/crier


### PR DESCRIPTION
Add Helm Charts to deploy jx image to serve build numbers using tot-like HTTP interface.
Runs a single instance of the build number service, and creates a Service to expose within
the cluster at buildnum:80
e.g. curl http://buildnum/vend/owner/repo/branch

I have left in the tot endpoint for now so we can switch over & test. Then will remove in a separate PR.