### PR TITLE
fix: add 'patch' verb

### DIFF
--- a/prow/templates/crier-clusterrole.yaml
+++ b/prow/templates/crier-clusterrole.yaml
@@ -12,3 +12,4 @@ rules:
   - list
   - watch
   - update
+  - patch


### PR DESCRIPTION
Seen occurrences where crier was trying to patch prowjobs, and failing.

```{"component":"crier","error":"prowjobs.prow.k8s.io \"64f43510-fa6b-11e8-a742-0a580a200227\" is forbidden: User \"system:serviceaccount:jx:crier\" cannot patch prowjobs.prow.k8s.io in the namespace \"keith-test-2\"","level":"error","msg":"failed to update report state","prowjob":"keith-test-2/64f43510-fa6b-11e8-a742-0a580a200227","time":"2018-12-12T09:15:16Z"}```