### PR TITLE
feat: add liveness & readiness probes for build number service.

### DIFF
--- a/prow/templates/buildnum-deployment.yaml
+++ b/prow/templates/buildnum-deployment.yaml
@@ -33,3 +33,11 @@ spec:
           - name: http
             containerPort: {{ .Values.buildnum.service.internalPort }}
             protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.buildnum.probe.livenessPath }}
+            port: http
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.buildnum.probe.readinessPath }}
+            port: http

--- a/prow/values.yaml
+++ b/prow/values.yaml
@@ -38,6 +38,9 @@ buildnum:
     jxTag: 1.3.812
   imagePullPolicy: IfNotPresent
   terminationGracePeriodSeconds: 180
+  probe:
+    livenessPath: /health
+    readinessPath: /ready
   command:
   - jx
   args:


### PR DESCRIPTION
Dependant on jx release [1.3.812](https://github.com/jenkins-x/jx/releases/tag/v1.3.812), which is already updated here.