### PR TITLE
chore: update the prow images tag

### DIFF
--- a/prow/templates/pipeline-clusterrole.yaml
+++ b/prow/templates/pipeline-clusterrole.yaml
@@ -24,3 +24,4 @@ rules:
   - list
   - watch
   - update
+  - patch

--- a/prow/values.yaml
+++ b/prow/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gcr.io/jenkinsxio/prow 
-  tag: v20190411-7d0bf795c
+  tag: v20190411-88a8176fb
 
 deck:
   replicaCount: 2


### PR DESCRIPTION
This version updates the build ID and URL in the prow job status and uses patch 
when updating the prow job.