### PR TITLE
fix: disable the plugin help endpoint exposed by hook service

### DIFF
--- a/prow/values.yaml
+++ b/prow/values.yaml
@@ -165,6 +165,7 @@ hook:
   terminationGracePeriodSeconds: 180
   args:
     - --dry-run=false
+    - --plugin-help=false 
   resources:
     limits:
      cpu: 400m


### PR DESCRIPTION
fixes https://github.com/cloudbees/jenkins-x-security/issues/3