### PR TITLE
fix: Switch to v1/apps for k8s 1.16+ support

### DIFF
--- a/prow/templates/build-deployment.yaml
+++ b/prow/templates/build-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.build.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "build.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "build.name" . }}
 spec:
   replicas: {{ .Values.build.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "build.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/buildnum-deployment.yaml
+++ b/prow/templates/buildnum-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.buildnum.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "buildnum.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "buildnum.name" . }}
 spec:
   replicas: 1 # one canonical source of build numbers
+  selector:
+    matchLabels:
+      app: {{ template "buildnum.name" . }}
   strategy:
     type: RollingUpdate
   template:

--- a/prow/templates/crier-deployment.yaml
+++ b/prow/templates/crier-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "crier.name" . }}
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "crier.name" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "crier.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/deck-deployment.yaml
+++ b/prow/templates/deck-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.deck.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "deck.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "deck.name" . }}
 spec:
   replicas: {{ .Values.deck.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "deck.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/hook-deployment.yaml
+++ b/prow/templates/hook-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "hook.name" . }}
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "hook.name" . }}
 spec:
   replicas: {{ .Values.hook.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "hook.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/horologium-deployment.yaml
+++ b/prow/templates/horologium-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.horologium.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "horologium.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "horologium.name" . }}
 spec:
   replicas: {{ .Values.horologium.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "horologium.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/pipeline-deployment.yaml
+++ b/prow/templates/pipeline-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "pipeline.name" . }}
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "pipeline.name" . }}
 spec:
   replicas: {{ .Values.pipeline.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "pipeline.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/pipelinerunner-deployment.yaml
+++ b/prow/templates/pipelinerunner-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pipelinerunner.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "pipelinerunner.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "pipelinerunner.name" . }}
 spec:
   replicas: 1 # one canonical source of build numbers
+  selector:
+    matchLabels:
+      app: {{ template "pipelinerunner.name" . }}
   strategy:
     type: RollingUpdate
   template:

--- a/prow/templates/plank-deployment.yaml
+++ b/prow/templates/plank-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.plank.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "plank.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "plank.name" . }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "plank.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/sinker-deployment.yaml
+++ b/prow/templates/sinker-deployment.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.sinker.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sinker.name" . }}
@@ -7,6 +7,9 @@ metadata:
     app: {{ template "sinker.name" . }}
 spec:
   replicas: {{ .Values.sinker.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "sinker.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/prow/templates/tide-deployment.yaml
+++ b/prow/templates/tide-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "tide.name" . }}
@@ -6,6 +6,9 @@ metadata:
     app: {{ template "tide.name" . }}
 spec:
   replicas: {{ .Values.tide.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "tide.name" . }}
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Specifically picking up a reverted commit and fixing the
`pipelinerunner` deployment in it.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>